### PR TITLE
fix: handle multipolygon dissolve results

### DIFF
--- a/backend/src/sources/parsers/water_projects.py
+++ b/backend/src/sources/parsers/water_projects.py
@@ -268,9 +268,20 @@ class WaterProjects(Source):
                 # Create dissolved version
                 logger.info("Creating dissolved version...")
                 try:
-                    # Dissolve using already validated geometries
+                    # Check what we got from dissolve
                     dissolved = unary_union(combined_gdf.geometry.values)
-                    dissolved_gdf = gpd.GeoDataFrame(geometry=[dissolved], crs=combined_gdf.crs)
+                    logger.info(f"Dissolved geometry type: {dissolved.geom_type}")
+                    
+                    # If it's a MultiPolygon, split into separate polygons
+                    if dissolved.geom_type == 'MultiPolygon':
+                        logger.info(f"Got MultiPolygon with {len(dissolved.geoms)} parts")
+                        # Create a row for each polygon
+                        geometries = list(dissolved.geoms)
+                        dissolved_gdf = gpd.GeoDataFrame(geometry=geometries, crs="EPSG:25832")
+                        logger.info(f"Created GeoDataFrame with {len(dissolved_gdf)} separate polygons")
+                    else:
+                        # Single polygon case
+                        dissolved_gdf = gpd.GeoDataFrame(geometry=[dissolved], crs="EPSG:25832")
                     
                     # Final validation and transformation
                     logger.info("Performing final validation...")


### PR DESCRIPTION
- Split dissolved MultiPolygon into separate polygon features
- Create individual rows for each disjointed polygon
- Add logging for MultiPolygon handling
- Preserve all polygons instead of selecting largest